### PR TITLE
Fix HDF4 import error in raster.py

### DIFF
--- a/pygaarst/raster.py
+++ b/pygaarst/raster.py
@@ -35,7 +35,7 @@ from pygaarst.landsat import Landsatscene, Landsatband
 from pygaarst.ali import ALIscene, ALIband
 from pygaarst.hyperion import Hyperionscene, Hyperionband
 from pygaarst.hdf5 import HDF5, VIIRSHDF5
-from pygaarst.hdf5 import HDF4, MODSWHDF4
+from pygaarst.hdf4 import HDF4, MODSWHDF4
 
 ### to be refactored
 


### PR DESCRIPTION
Hi, Just looking at using some Hyperion data at the moment and was having problems importing raster - everytime I tried to do so it failed at importing the pygaarst HDF4 class. Bug fix in this pull request. cheers, Andrew
